### PR TITLE
Force matrix for cumulative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: iBreakDown
 Title: Model Agnostic Instance Level Variable Attributions
-Version: 2.1.1
+Version: 2.1.2
 Authors@R: c(person("Przemyslaw", "Biecek", email = "przemyslaw.biecek@gmail.com", role = c("aut", "cre"), 
              comment = c(ORCID = "0000-0001-8423-1823")),
     person("Alicja", "Gosiewska", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+iBreakDown 2.1.2
+---------------------------------------------------------------
+* force matrix class for cumulative contributions in the calculate_contributions_along_path to prevent iBreakDown breaking for multiclass classification
+  models that return data.frame of probabilities instead of a matrix.
+
 iBreakDown 2.1.1
 ---------------------------------------------------------------
 * consistent theme settings with [#541](https://github.com/ModelOriented/DALEX/issues/541)

--- a/R/local_attributions.R
+++ b/R/local_attributions.R
@@ -246,7 +246,7 @@ calculate_contributions_along_path <- function(x,
   variable       <- c("intercept",
                       paste0(colnames(current_data)[selected$ind1], " = ",  selected_values) ,
                       "prediction")
-  cumulative <- do.call(rbind, c(list(baseline_yhat), yhats_mean, list(target_yhat)))
+  cumulative <- as.matrix(do.call(rbind, c(list(baseline_yhat), yhats_mean, list(target_yhat))))
   contribution <- rbind(0,apply(cumulative, 2, diff))
   contribution[1,] <- cumulative[1,]
   contribution[nrow(contribution),] <- cumulative[nrow(contribution),]


### PR DESCRIPTION
Candidate fix for https://github.com/ModelOriented/DALEXtra/issues/89

iBreakDown could break for multiclass classification models that are returning data.frame of probabilities instead of matrix. By enforcing cumulative to always be a matrix we will prevent such situations and make iBreakDown applicable for bigger class of packages.